### PR TITLE
build: :lock: patch path-to-regexp vulnerabilities using npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2309,9 +2309,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "flatted": "^3.4.2",
     "minimatch": "^10.2.4",
     "picomatch": "^4.0.4",
-    "lodash": "^4.17.23"
+    "lodash": "^4.17.23",
+    "path-to-regexp": "^8.4.1"
   }
 }


### PR DESCRIPTION
Resolved two security vulnerabilities identified by Dependabot for the 
'path-to-regexp' package by utilising the npm overrides field:

1. path-to-regexp (DoS via sequential optional groups - High):
   - Mitigated a vulnerability where sequential optional groups could 
     cause the generated regex to grow exponentially, leading to DoS.
   - Enforced resolution to ^8.4.0 to secure the routing engine.

2. path-to-regexp (ReDoS via multiple wildcards - Moderate):
   - Patched a backtracking vulnerability triggered by multiple wildcards 
     combined with at least one parameter.

Changes:
- Added 'path-to-regexp' resolution to the "overrides" block.
- Regenerated package-lock.json to enforce the secure version across 
  transitive dependencies (originating from express).