### PR TITLE
build: :lock: patch lodash vulnerabilities using npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,9 +1798,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "flatted": "^3.4.2",
     "minimatch": "^10.2.4",
     "picomatch": "^4.0.4",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "path-to-regexp": "^8.4.1"
   }
 }


### PR DESCRIPTION
Resolved two security vulnerabilities identified in the lodash package 
by updating its resolution via npm overrides:

1. Code Injection via `_.template` (High):
   - Mitigated a vulnerability where `_.template` could allow code injection 
     through imported key names.
     
2. Prototype Pollution in `_.unset` and `_.omit` (Moderate):
   - Patched a prototype pollution flaw caused by an array path bypass.

Changes:
- Bumped 'lodash' version in the "overrides" block.
- Regenerated package-lock.json to enforce the secure version across 
  all transitive dependencies.